### PR TITLE
[ci] update scm url

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -26,7 +26,7 @@
         reference-repo: /var/lib/jenkins/.git-references/elasticsearch-dsl-js.git
         branches:
         - ${branch_specifier}
-        url: https://github.com/elastic/elasticsearch-dsl-js.git
+        url: git@github.com:elastic/elasticsearch-dsl-js.git
         wipe-workspace: 'True'
     triggers:
     - github


### PR DESCRIPTION
The git plugin needs a git URL rather than HTTP to work with our
credentials.