### PR TITLE
chore: add move notifications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,82 +22,16 @@ on:
         default: 'main'
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
-  publish:
-    name: Publish
+  disabled:
+    name: Publish disabled - repository moved
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.inputs.branch }}
-
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: '24.8.0'
-          cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@elastic'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run tests
-        run: pnpm run test
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Publish query-builder
-        if: ${{ github.event.inputs.package == 'query-builder' || github.event.inputs.package == 'all' }}
-        run: pnpm publish --access public --no-git-checks --tag ${{ github.event.inputs.tag }} --provenance
-        working-directory: packages/query-builder
-
-      - name: Publish esql-dsl
-        if: ${{ github.event.inputs.package == 'esql-dsl' || github.event.inputs.package == 'all' }}
-        run: pnpm publish --access public --no-git-checks --tag ${{ github.event.inputs.tag }} --provenance
-        working-directory: packages/esql-dsl
-
-      - name: Publish search-dsl
-        if: ${{ github.event.inputs.package == 'search-dsl' || github.event.inputs.package == 'all' }}
-        run: pnpm publish --access public --no-git-checks --tag ${{ github.event.inputs.tag }} --provenance
-        working-directory: packages/search-dsl
-
-      - name: Create GitHub Release
-        if: ${{ github.event.inputs.tag == 'latest' }}
+      - name: Fail with pointer to new location
         run: |
-          get_version() { node -p "require('./packages/$1/package.json').version"; }
-          case "${{ github.event.inputs.package }}" in
-            query-builder)
-              gh release create "query-builder-v$(get_version query-builder)" \
-                --title "query-builder v$(get_version query-builder)" \
-                --generate-notes --target "${{ github.event.inputs.branch }}"
-              ;;
-            esql-dsl)
-              gh release create "esql-dsl-v$(get_version esql-dsl)" \
-                --title "esql-dsl v$(get_version esql-dsl)" \
-                --generate-notes --target "${{ github.event.inputs.branch }}"
-              ;;
-            search-dsl)
-              gh release create "search-dsl-v$(get_version search-dsl)" \
-                --title "search-dsl v$(get_version search-dsl)" \
-                --generate-notes --target "${{ github.event.inputs.branch }}"
-              ;;
-            all)
-              gh release create "esql-dsl-v$(get_version esql-dsl)" \
-                --title "esql-dsl v$(get_version esql-dsl)" \
-                --generate-notes --target "${{ github.event.inputs.branch }}"
-              gh release create "query-builder-v$(get_version query-builder)" \
-                --title "query-builder v$(get_version query-builder)" \
-                --generate-notes --target "${{ github.event.inputs.branch }}"
-              gh release create "search-dsl-v$(get_version search-dsl)" \
-                --title "search-dsl v$(get_version search-dsl)" \
-                --generate-notes --target "${{ github.event.inputs.branch }}"
-              ;;
-          esac
-        env:
-          GH_TOKEN: ${{ github.token }}
+          echo "::error::This repository has moved to elastic/esql-js (packages/esql-dsl and packages/query-builder)."
+          echo "::error::Releases are now published from that monorepo. This workflow is disabled to prevent accidental npm publishes from the old repo."
+          echo "::error::See https://github.com/elastic/esql-js/tree/main/packages/esql-dsl"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,12 @@
 # Contributing to Elasticsearch DSL Libraries
 
+> [!IMPORTANT]
+> This repository has moved to the
+> [`elastic/esql-js`](https://github.com/elastic/esql-js) monorepo, under
+> [`packages/esql-dsl`](https://github.com/elastic/esql-js/tree/main/packages/esql-dsl) and
+> [`packages/query-builder`](https://github.com/elastic/esql-js/tree/main/packages/query-builder).
+> Please direct all contributions there; the guidance below no longer applies.
+
 Thank you for your interest in contributing!
 
 ## Development Setup

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Elasticsearch DSL Libraries for JavaScript/TypeScript
 
+> [!IMPORTANT]
+> This repository has moved. Development now happens in the
+> [`elastic/esql-js`](https://github.com/elastic/esql-js) monorepo:
+> `@elastic/elasticsearch-esql-dsl` lives in
+> [`packages/esql-dsl`](https://github.com/elastic/esql-js/tree/main/packages/esql-dsl)
+> and `@elastic/elasticsearch-query-builder` in
+> [`packages/query-builder`](https://github.com/elastic/esql-js/tree/main/packages/query-builder).
+> Please open issues and pull requests there instead of here. This repository
+> is kept for historical reference only and is no longer maintained.
+
 [![CI](https://github.com/elastic/elasticsearch-dsl-js/actions/workflows/ci.yml/badge.svg)](https://github.com/elastic/elasticsearch-dsl-js/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,8 +4,12 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: elasticsearch-dsl-js
-  description: Fluent, type-safe DSL libraries for building Elasticsearch queries in JavaScript and TypeScript
+  description: >
+    Fluent, type-safe DSL libraries for building Elasticsearch queries in
+    JavaScript and TypeScript.
+    DEPRECATED: this repository has moved to elastic/esql-js
+    (packages/esql-dsl and packages/query-builder).
 spec:
   type: library
   owner: group:devtools-team
-  lifecycle: production
+  lifecycle: deprecated

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "elasticsearch-dsl-js",
   "version": "0.0.0",
   "private": true,
-  "description": "Elasticsearch DSL libraries for JavaScript/TypeScript",
+  "description": "DEPRECATED: moved to the elastic/esql-js monorepo (packages/esql-dsl and packages/query-builder). Elasticsearch DSL libraries for JavaScript/TypeScript",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/elastic/elasticsearch-dsl-js.git"

--- a/packages/esql-dsl/README.md
+++ b/packages/esql-dsl/README.md
@@ -1,5 +1,12 @@
 # @elastic/elasticsearch-esql-dsl
 
+> [!IMPORTANT]
+> This package has moved to the
+> [`elastic/esql-js`](https://github.com/elastic/esql-js) monorepo, under
+> [`packages/esql-dsl`](https://github.com/elastic/esql-js/tree/main/packages/esql-dsl).
+> Please open issues and pull requests there instead of here. This repository
+> is kept for historical reference only and is no longer maintained.
+
 > **Technical Preview:** This package is in technical preview and may be changed or removed in a future release.
 
 A fluent, type-safe ES|QL query builder for JavaScript and TypeScript. Build ES|QL queries using method chaining and render them to query strings for use with the Elasticsearch client.

--- a/packages/esql-dsl/package.json
+++ b/packages/esql-dsl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/elasticsearch-esql-dsl",
   "version": "1.0.1",
-  "description": "Elasticsearch ES|QL DSL for JavaScript/TypeScript",
+  "description": "DEPRECATED: moved to the elastic/esql-js monorepo (packages/esql-dsl). Elasticsearch ES|QL DSL for JavaScript/TypeScript",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/query-builder/README.md
+++ b/packages/query-builder/README.md
@@ -1,5 +1,12 @@
 # @elastic/elasticsearch-query-builder
 
+> [!IMPORTANT]
+> This package has moved to the
+> [`elastic/esql-js`](https://github.com/elastic/esql-js) monorepo, under
+> [`packages/query-builder`](https://github.com/elastic/esql-js/tree/main/packages/query-builder).
+> Please open issues and pull requests there instead of here. This repository
+> is kept for historical reference only and is no longer maintained.
+
 Shared utilities for building Elasticsearch queries in JavaScript/TypeScript: operator symbols, escaping helpers, and a base expression type for cross-package type checks.
 
 ## Installation

--- a/packages/query-builder/package.json
+++ b/packages/query-builder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/elasticsearch-query-builder",
   "version": "1.0.0",
-  "description": "Elasticsearch Query Builder for JavaScript/TypeScript",
+  "description": "DEPRECATED: moved to the elastic/esql-js monorepo (packages/query-builder). Elasticsearch Query Builder for JavaScript/TypeScript",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Description

The development of packages in this repo has moved to https://github.com/elastic/esql-js

This PR adds notifications of this move in various places across the repo

Adds the following note to README:

> [!IMPORTANT]
> This repository has moved. Development now happens in the [`elastic/esql-js`](https://github.com/elastic/esql-js) monorepo: `@elastic/elasticsearch-esql-dsl` lives in [`packages/esql-dsl`](https://github.com/elastic/esql-js/tree/main/packages/esql-dsl) and `@elastic/elasticsearch-query-builder` in [`packages/query-builder`](https://github.com/elastic/esql-js/tree/main/packages/query-builder). Please open issues and pull requests there instead of here. This repository is kept for historical reference only and is no longer maintained.